### PR TITLE
Fix the issuer implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ $ TOKEN=$(cat DEFAULT.token) \
 ```
 
 You should see `X-Factor-Client-Id: DEFAULT` in the response from the server.
-Note that in this case we are generating an oidc token an validating it
+Note that in this case we are generating an oidc token and validating it
 locally.
 
 ## Governance and Code of Conduct
@@ -171,3 +171,16 @@ the environment. Identity data looks like:
 If a matching token is supplied, then the header `X-Factor-Client-Id` will be
 set to the value of the matching client id. To reject, requests that don't
 match, use the flag `--reject-unknown`
+
+`factor issuer`
+
+Prints out the issuer and subject for the application. If factor is already
+running it will dynamically print out the current issuer, otherwise loads the
+identity provider to determine the issuer.
+
+The output will be something like:
+
+```
+issuer=http://localhost:5000
+subject=local
+```

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -9,7 +9,7 @@ use log::{error, info, trace, warn};
 pub use providers::*;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use tokio::{fs::File, io::AsyncWriteExt, sync::watch, time::interval};
+use tokio::{fs::write, sync::watch, time::interval};
 
 use super::{dirs, env, server::Service};
 
@@ -117,8 +117,7 @@ impl IdentitySyncService {
 
     async fn write_issuer(&self) -> Result<()> {
         let issuer = self.provider.get_iss().await?;
-        let mut file = File::create(&self.issuer_path).await?;
-        file.write_all(issuer.as_bytes()).await?;
+        write(&self.issuer_path, issuer.as_bytes()).await?;
         Ok(())
     }
 }

--- a/src/identity/providers/auth0.rs
+++ b/src/identity/providers/auth0.rs
@@ -85,9 +85,8 @@ struct Auth0Response {
 
 #[async_trait]
 impl IdentityProvider for Provider {
-    async fn get_iss_and_jwks(&self) -> Result<Option<(String, String)>> {
-        // No jwks management
-        Ok(None)
+    async fn get_iss(&self) -> Result<String> {
+        self.config.issuer.clone().context("Issuer not configured")
     }
 
     async fn configure_app_identity(&self, name: &str) -> Result<ProviderConfig> {

--- a/src/identity/providers/dummy.rs
+++ b/src/identity/providers/dummy.rs
@@ -37,9 +37,8 @@ impl Provider {
 
 #[async_trait]
 impl IdentityProvider for Provider {
-    async fn get_iss_and_jwks(&self) -> Result<Option<(String, String)>> {
-        // No jwks management
-        Ok(None)
+    async fn get_iss(&self) -> Result<String> {
+        Ok("dummy-issuer".to_string())
     }
     async fn configure_app_identity(&self, name: &str) -> Result<ProviderConfig> {
         let mut config = self.config.clone();

--- a/src/identity/providers/local.rs
+++ b/src/identity/providers/local.rs
@@ -132,11 +132,13 @@ struct Claims {
 
 #[async_trait]
 impl IdentityProvider for Provider {
-    async fn get_iss_and_jwks(&self) -> Result<Option<(String, String)>> {
+    async fn get_iss(&self) -> Result<String> {
         // if iss is still an env var, expand it now
-        let iss = env::expand(&self.config.iss)?;
+        env::expand(&self.config.iss)
+    }
+    async fn get_jwks(&self) -> Result<Option<String>> {
         let json = serde_json::to_string_pretty(&self.jwks)?;
-        Ok(Some((iss, json)))
+        Ok(Some(json))
     }
 
     async fn configure_app_identity(&self, name: &str) -> Result<ProviderConfig> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,11 +310,8 @@ fn handle_issuer(app_config: &AppConfig) -> Result<(), anyhow::Error> {
     let issuer = if let Ok(iss) = identity::get_stored_issuer() {
         iss
     } else {
-        info!("Could not get stored issuer, falling back to generating a token");
-        // Generate a token with a dummy audience to extract issuer
-        let token = rt.block_on(provider.get_token("dummy-audience"))?;
-        let claims = identity::get_claims(&token)?;
-        claims.iss
+        info!("Could not get stored issuer, falling back to provider");
+        rt.block_on(provider.get_iss())?
     };
 
     // Get subject directly


### PR DESCRIPTION
Issuer did not properly support any provider other than local.

This fixes the implementation by implementing get_iss for all providers. This also allows us to avoid having to create a token as the fallback for discovery.