### PR TITLE
Rename issuer to info and add more metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,15 +172,17 @@ If a matching token is supplied, then the header `X-Factor-Client-Id` will be
 set to the value of the matching client id. To reject, requests that don't
 match, use the flag `--reject-unknown`
 
-`factor issuer`
+`factor info`
 
-Prints out the issuer and subject for the application. If factor is already
-running it will dynamically print out the current issuer, otherwise loads the
-identity provider to determine the issuer.
+Prints out info for the current application. If factor is already running it
+will dynamically print out the current data, otherwise loads the identity
+provider to determine the values.
 
 The output will be something like:
 
 ```
-issuer=http://localhost:5000
-subject=local
+name=local
+url=http://localhost:5000
+iss=http://localhost:5000
+sub=local
 ```

--- a/example.factor-app
+++ b/example.factor-app
@@ -1,10 +1,11 @@
 app = "local"
 path = "."
+# if the app is behind a gateway, specify the url here
+# url = "https://example.com"
 
 [id]
 name = "local"
 provider = "local"
-iss = "$NGROK_URL" # if not using ngrok, set issuer to public hostname of app
 secret = "..." # base64 encoded bootstrap secret -> openssl rand -base64 32
 sub = "local"
 

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use directories::ProjectDirs;
+use tokio::fs::write;
 
 const QUALIFIER: &str = "dev";
 const ORGANIZATION: &str = "twelve-factor";
@@ -32,4 +33,99 @@ pub fn home_dir() -> Result<PathBuf> {
     directories::BaseDirs::new()
         .ok_or_else(|| anyhow::anyhow!("Could not find home directory"))
         .map(|dirs| dirs.home_dir().to_path_buf())
+}
+
+const URL_FILENAME: &str = "url";
+const ISS_FILENAME: &str = "issuer";
+
+/// Get the stored url from the data directory
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Cannot access data directory
+/// - Url file doesn't exist or can't be read
+pub fn get_stored_url() -> Result<String> {
+    let url_path = get_data_dir()?.join(URL_FILENAME);
+    std::fs::read_to_string(&url_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read url file: {}", e))
+}
+
+/// Write the url for the app to the data directory
+/// # Errors
+///
+/// Returns an error if:
+/// - Cannot access data directory
+/// - `write` returns an error, which can happen if:
+///     - The file cannot be created or opened.
+///     - There is an error writing to the file.
+///     - See [`tokio::fs::write`].
+pub async fn write_url(url: String) -> Result<()> {
+    let url_path = get_data_dir()?.join(URL_FILENAME);
+    write(&url_path, url.as_bytes()).await?;
+    Ok(())
+}
+
+/// Delete the url file from the data directory
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Cannot access data directory
+/// - `remove_file` returns an error, which can happen if:
+///     - The file doesn't exist.
+///     - The user lacks permissions to remove the file.
+///     - Some other I/O error occurred.
+///     - See [`tokio::fs::remove_file`].
+pub async fn delete_url() -> Result<()> {
+    let data_dir = get_data_dir()?;
+    let url_path = data_dir.join(URL_FILENAME);
+    tokio::fs::remove_file(&url_path).await?;
+    Ok(())
+}
+
+/// Get the stored iss from the data directory
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Cannot access data directory
+/// - Iss file doesn't exist or can't be read
+pub fn get_stored_iss() -> Result<String> {
+    let iss_path = get_data_dir()?.join(ISS_FILENAME);
+    std::fs::read_to_string(&iss_path)
+        .map_err(|e| anyhow::anyhow!("Failed to read iss file: {}", e))
+}
+
+/// Write the iss for the app to the data directory
+/// # Errors
+///
+/// Returns an error if:
+/// - Cannot access data directory
+/// - `write` returns an error, which can happen if:
+///     - The file cannot be created or opened.
+///     - There is an error writing to the file.
+///     - See [`tokio::fs::write`].
+pub async fn write_iss(iss: String) -> Result<()> {
+    let iss_path = get_data_dir()?.join(ISS_FILENAME);
+    write(&iss_path, iss.as_bytes()).await?;
+    Ok(())
+}
+
+/// Delete the iss file from the data directory
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Cannot access data directory
+/// - `remove_file` returns an error, which can happen if:
+///     - The file doesn't exist.
+///     - The user lacks permissions to remove the file.
+///     - Some other I/O error occurred.
+///     - See [`tokio::fs::remove_file`].
+pub async fn delete_iss() -> Result<()> {
+    let data_dir = get_data_dir()?;
+    let iss_path = data_dir.join(ISS_FILENAME);
+    tokio::fs::remove_file(&iss_path).await?;
+    Ok(())
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use anyhow::Result;
+use log::error;
 use notify::{Event, RecursiveMode, Watcher};
 use reqwest;
 use serde::de::DeserializeOwned;
@@ -51,7 +52,10 @@ where
 
     let string_value = var_with_on_change(key, string_callback)?;
 
-    let value = serde_json::from_str(&string_value).map_err(|_| VarError::NotPresent)?;
+    let value = serde_json::from_str(&string_value).map_err(|e| {
+        error!("Failed to parse JSON: {}", e);
+        VarError::NotPresent
+    })?;
     Ok(value)
 }
 
@@ -68,7 +72,10 @@ where
     T: DeserializeOwned + Send + Sync + 'static,
 {
     let string_value = var(key)?;
-    let value = serde_json::from_str(&string_value).map_err(|_| VarError::NotPresent)?;
+    let value = serde_json::from_str(&string_value).map_err(|e| {
+        error!("Failed to parse JSON: {}", e);
+        VarError::NotPresent
+    })?;
     Ok(value)
 }
 


### PR DESCRIPTION
This renames the `issuer` command to `info` and adds the app name and url to the data printed. Output now looks like:

```
name=local
url=http://localhost:5000
iss=http://localhost:5000
sub=local
```